### PR TITLE
Add GitHub Actions workflow 'tests.yml' and (test_dummy.py)for running pytest and uploading coverage to Codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,41 @@
+name: Run tests and upload coverage
+
+on:
+  push:
+    branches:
+      - mywork       # runs when you push to your personal branch
+      - develop      # runs when pushing to develop
+  pull_request:
+    branches:
+      - develop      # runs on PRs into develop
+      - main         # runs on PRs into main
+
+jobs:
+  test:
+    name: Run tests and collect coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"   # adjust if you need a different version
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Run tests with coverage
+        run: pytest --cov=SeqKit_tools --cov-branch --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,0 +1,2 @@
+def test_dummy():
+    assert True


### PR DESCRIPTION
This workflow should automatically runs Pytest on pushes to mywork and develop branches, runs on pull requests to develop and main, and uploads coverage reports to Codecov for tracking test coverage. (Note: my initial pull request targeted the 'develop' branch, and this pull request targets 'personal_work' branch) (Note: 2nd attempt I added a test_dummy.py).
